### PR TITLE
chore: update swagger config

### DIFF
--- a/src/helpers/configure-swagger-docs.helper.ts
+++ b/src/helpers/configure-swagger-docs.helper.ts
@@ -29,7 +29,7 @@ export function configureSwaggerDocs(
       .addTag('auth')
       .addTag('users')
       .build();
-    const document = SwaggerModule.createDocument(app, config);
-    SwaggerModule.setup('/docs', app, document);
+    const documentFactory = () => SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('/docs', app, documentFactory);
   }
 }


### PR DESCRIPTION
- The factory around `SwaggerModule#createDocument()` is only used to create the document when you actually request Swagger (when it is used), saving initialization time
