### PR TITLE
fix: remove hardcoded JWT secret from .env.example and fix IDOR in user CRUD routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ FASTIFY_ADDRESS=0.0.0.0
 SWAGGER_USER=""
 SWAGGER_PASSWORD=""
 
-SECRET_KEY_JWT=secret
+SECRET_KEY_JWT=
 
 # Database - Development
 DB_HOST=localhost

--- a/@types/fastify.d.ts
+++ b/@types/fastify.d.ts
@@ -34,7 +34,7 @@ declare module "fastify" {
       sub: string;
       name: string;
       email: string;
-      role: Role;
+      role: Role[];
     };
   }
 

--- a/src/modules/authentication/authentication.routes.ts
+++ b/src/modules/authentication/authentication.routes.ts
@@ -118,7 +118,7 @@ const authenticationRoutes: FastifyPluginAsyncTypebox = async (
     { preHandler: [fastify.checkToken], schema: userAuthenticatedSchema },
     async function (request, reply) {
       try {
-        const userId = (request.user as { sub: string }).sub;
+        const userId = request.user.sub;
         const result = await fastify.authenticationService.getUserData(userId);
         return reply.status(200).send(result);
       } catch (err) {

--- a/src/modules/users/users.routes.ts
+++ b/src/modules/users/users.routes.ts
@@ -50,8 +50,8 @@ const usersRoutes: FastifyPluginAsyncTypebox = async (fastify: FastifyInstance) 
       schema: getUserSchema
     },
     async (request: FastifyRequest<{ Params: UserParams }>, reply: FastifyReply) => {
-      const userId = (request.user as { sub: string; role: string[] }).sub;
-      const userRole = (request.user as { role: string[] }).role;
+      const userId = request.user.sub;
+      const userRole = request.user.role;
       if (request.params.id !== userId && !userRole.includes('ADMIN')) {
         return reply.code(403).send({ error: "Forbidden: cannot access other user data" });
       }
@@ -71,8 +71,8 @@ const usersRoutes: FastifyPluginAsyncTypebox = async (fastify: FastifyInstance) 
     },
     async (request: FastifyRequest<{ Params: UserParams; Body: UpdateUserDto }>, reply: FastifyReply) => {
       try {
-        const userId = (request.user as { sub: string; role: string[] }).sub;
-        const userRole = (request.user as { role: string[] }).role;
+        const userId = request.user.sub;
+        const userRole = request.user.role;
         if (request.params.id !== userId && !userRole.includes('ADMIN')) {
           return reply.code(403).send({ error: "Forbidden: cannot modify other user data" });
         }
@@ -95,8 +95,8 @@ const usersRoutes: FastifyPluginAsyncTypebox = async (fastify: FastifyInstance) 
       schema: deleteUserSchema
     },
     async (request: FastifyRequest<{ Params: UserParams }>, reply: FastifyReply) => {
-      const userId = (request.user as { sub: string; role: string[] }).sub;
-      const userRole = (request.user as { role: string[] }).role;
+      const userId = request.user.sub;
+      const userRole = request.user.role;
       if (request.params.id !== userId && !userRole.includes('ADMIN')) {
         return reply.code(403).send({ error: "Forbidden: cannot delete other user" });
       }

--- a/src/modules/users/users.routes.ts
+++ b/src/modules/users/users.routes.ts
@@ -9,14 +9,14 @@ import {
   UpdateUserDto,
   UserParams
 } from "./users.schema";
-import { FastifyInstance } from "fastify";
+import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 
 const usersRoutes: FastifyPluginAsyncTypebox = async (fastify: FastifyInstance) => {
 
   fastify.post<{ Body: CreateUserDto }>(
     "/",
     {
-      preHandler: [fastify.checkToken],
+      preHandler: [fastify.checkToken, fastify.checkRole('ADMIN')],
       schema: createUserSchema
     },
     async (request, reply) => {
@@ -30,11 +30,11 @@ const usersRoutes: FastifyPluginAsyncTypebox = async (fastify: FastifyInstance) 
     }
   );
 
-  // GET ALL
+  // GET ALL — restricted to ADMIN only
   fastify.get(
     "/",
     {
-      preHandler: [fastify.checkToken],
+      preHandler: [fastify.checkToken, fastify.checkRole('ADMIN')],
       schema: getAllUsersSchema
     },
     async (_, reply) => {
@@ -49,7 +49,12 @@ const usersRoutes: FastifyPluginAsyncTypebox = async (fastify: FastifyInstance) 
       preHandler: [fastify.checkToken],
       schema: getUserSchema
     },
-    async (request, reply) => {
+    async (request: FastifyRequest<{ Params: UserParams }>, reply: FastifyReply) => {
+      const userId = (request.user as { sub: string; role: string[] }).sub;
+      const userRole = (request.user as { role: string[] }).role;
+      if (request.params.id !== userId && !userRole.includes('ADMIN')) {
+        return reply.code(403).send({ error: "Forbidden: cannot access other user data" });
+      }
       const user = await fastify.usersService.getUserById(request.params.id);
       if (!user) {
         return reply.code(404).send({ error: "User not found" });
@@ -64,8 +69,13 @@ const usersRoutes: FastifyPluginAsyncTypebox = async (fastify: FastifyInstance) 
       preHandler: [fastify.checkToken],
       schema: updateUserSchema
     },
-    async (request, reply) => {
+    async (request: FastifyRequest<{ Params: UserParams; Body: UpdateUserDto }>, reply: FastifyReply) => {
       try {
+        const userId = (request.user as { sub: string; role: string[] }).sub;
+        const userRole = (request.user as { role: string[] }).role;
+        if (request.params.id !== userId && !userRole.includes('ADMIN')) {
+          return reply.code(403).send({ error: "Forbidden: cannot modify other user data" });
+        }
         const user = await fastify.usersService.updateUser(
           request.params.id,
           request.body
@@ -84,7 +94,12 @@ const usersRoutes: FastifyPluginAsyncTypebox = async (fastify: FastifyInstance) 
       preHandler: [fastify.checkToken],
       schema: deleteUserSchema
     },
-    async (request, reply) => {
+    async (request: FastifyRequest<{ Params: UserParams }>, reply: FastifyReply) => {
+      const userId = (request.user as { sub: string; role: string[] }).sub;
+      const userRole = (request.user as { role: string[] }).role;
+      if (request.params.id !== userId && !userRole.includes('ADMIN')) {
+        return reply.code(403).send({ error: "Forbidden: cannot delete other user" });
+      }
       await fastify.usersService.deleteUser(request.params.id);
       return reply.status(204).send();
     }

--- a/src/plugins/authorization/check-role.plugin.ts
+++ b/src/plugins/authorization/check-role.plugin.ts
@@ -7,7 +7,7 @@ async function checkRolePlugin(fastify: FastifyInstance) {
       const user = request.user;
 
       if (typeof user === "object" && user !== null && "role" in user) {
-        const roles = user.role as string[];
+        const roles = user.role;
         const userRole = roles[0];
         if (userRole !== requiredRole) {
           reply.code(403).send({ message: "Insufficient permissions" });


### PR DESCRIPTION
## Summary

Two security issues were found in this boilerplate:

1. **CWE-798**: The  ships with  as the default JWT signing key, allowing token forgery by anyone who knows this public value.
2. **CWE-639 (IDOR)**: The  CRUD routes only require a valid JWT but do not enforce ownership — any authenticated user can read/modify/delete any other user.

---

## Issue 1: Hardcoded JWT Secret (CWE-798)

### Vulnerable Code

- The example environment file provides a weak, predictable JWT secret
- The  validation requires the key to be a non-empty string, and  passes trivially
- The secret is passed directly to  for token signing
- All access tokens are signed with this key


### Data Flow


### Impact

Anyone who reads the public  knows the default signing key. If a developer copies the example to  without changing the secret, an attacker can:
- Forge valid JWT access tokens for any user ID
- Bypass all JWT-based authentication ( preHandler)
- Access all authenticated endpoints

### Fix

Changed the default value to an empty string. The  already has a guard that throws if  is falsy:


**(AFTER):**


This forces the developer to set a proper random key before the application can start.

---

## Issue 2: IDOR in User CRUD Routes (CWE-639)

### Vulnerable Code

**(BEFORE)** — All four CRUD routes only check for a valid JWT, with no ownership validation:



### Data Flow


### Impact

A user registered with  (which assigns ) can:
- **Read** all users' emails, names, and metadata via 
- **Read** any specific user via 
- **Update** any user's profile via 
- **Delete** any user via 

Note:  excludes  and  fields, preventing privilege escalation and password overwrite. However, the ability to modify or delete other users' accounts is still a serious authorization bypass.

### Fix

Added ownership checks in all param-based routes. Non-admin users can only access their own resources. Admin-only routes (list all, create) are now restricted with .

** (AFTER) — Example for GET /:id:**


---

## Additional Note

The  endpoint accepts any valid JWT as a refresh token — there is no distinction between access tokens and refresh tokens, and no token type claim is enforced. This means access tokens can be used to extend sessions indefinitely. A full refresh token rotation mechanism with dedicated  claims should be considered for production deployments.